### PR TITLE
Add better error message for urls without protocol

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -163,9 +163,13 @@ var fixer = module.exports = {
 
 ,  fixHomepageField: function(data) {
     if(!data.homepage) return true;
-    if(typeof data.homepage !== "string" || !url.parse(data.homepage).protocol) {
+    if(typeof data.homepage !== "string") {
       this.warn("homepage field must be a string url. Deleted.")
-      delete data.homepage
+      return delete data.homepage
+    }
+    if(!url.parse(data.homepage).protocol) {
+      this.warn("homepage field must start with a protocol.")
+      data.homepage = "http://" + data.homepage
     }
   }
 }

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -65,7 +65,7 @@ tap.test("urls required", function(t) {
   var a
   normalize(a={
     readme: "read yourself how about",
-    homepage: "stragle planarf",
+    homepage: 123,
     bugs: "what is this i don't even",
     repository: "Hello."
   }, warn)
@@ -82,6 +82,27 @@ tap.test("urls required", function(t) {
       'Normalized value of bugs field is an empty object. Deleted.',
       'homepage field must be a string url. Deleted.' ]
   t.same(warnings, expect)
+  t.end()
+})
+
+tap.test("homepage field must start with a protocol.", function(t) {
+  var warnings = []
+  function warn(w) {
+    warnings.push(w)
+  }
+  var a
+  normalize(a={
+    homepage: 'example.org'
+  }, warn)
+
+  console.error(a)
+
+  var expect =
+    [ 'No repository field.',
+      'No readme data.',
+      'homepage field must start with a protocol.' ]
+  t.same(warnings, expect)
+  t.same(a.homepage, 'http://example.org')
   t.end()
 })
 


### PR DESCRIPTION
Initially coming from `npm-www`: https://github.com/isaacs/npm-www/issues/338

Fixes #25
