### PR TITLE
don't warn if private = true

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -17,7 +17,7 @@ thingsToFix = thingsToFix.concat(otherThingsToFix)
 function normalize (data, warn, strict) {
   if(warn === true) warn = null, strict = true
   if(!strict) strict = false
-  if(!warn) warn = function(msg) { /* noop */ }
+  if(!warn || data.private) warn = function(msg) { /* noop */ }
 
   if (data.scripts && 
       data.scripts.install === "node-gyp rebuild" && 

--- a/test/typo.js
+++ b/test/typo.js
@@ -94,5 +94,15 @@ test('typos', function(t) {
 
   t.same(warnings, expect)
 
+  warnings.length = 0
+  expect = []
+
+  normalize({private: true
+            ,name:"name"
+            ,version:"1.2.5"
+            ,scripts:{server:"start",tests:"test"}}, warn)
+
+  t.same(warnings, expect)
+
   t.end();
 })


### PR DESCRIPTION
This fixes isaacs/npm#3490 where the conclusion is, that if
the package.json has a private = true, it should not warn.
