### PR TITLE
Allow shorthand style for the repository field

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -27,6 +27,9 @@ var fixer = module.exports = {
       var ghurl = parseGitHubURL(r)
       if (ghurl) {
         r = ghurl.replace(/^https?:\/\//, 'git://')
+      } else if (!/^(https?|git):\/\//.test(r) && /\w\/\w/.test(r)) {
+        // repo has 'user/reponame' filled in as repo
+        data.repository.url = "git://github.com/" + r
       }
     }
 

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -129,6 +129,13 @@ tap.test("singularize repositories", function(t) {
   t.end()
 });
 
+tap.test("treat visionmedia/express as github repo", function(t) {
+  var d = {repository: {type: "git", url: "visionmedia/express"}}
+  normalize(d)
+  t.same(d.repository, { type: "git", url: "git://github.com/visionmedia/express" })
+  t.end()
+});
+
 tap.test('no new globals', function(t) {
   t.same(Object.keys(global), globals)
   t.end()


### PR DESCRIPTION
If "user/reponame" is given as url in the repository field, create a
github-git-url from it.

Example:
user/reponame gets to: git://github.com/user/reponame

This fixes isaacs/npm#3783
