### PR TITLE
Export fixer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+exports = (module.exports = require("./lib/normalize"))
+exports.fixer = require("./lib/fixer")

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git://github.com/meryn/normalize-package-data.git"
   },
-  "main": "lib/normalize.js",
+  "main": "index.js",
   "scripts": {
     "test": "tap test/*.js"
   },

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,5 @@
 var tap = require("tap")
-var normalize = require("../lib/normalize")
+var normalize = require("../index")
 var path = require("path")
 var fs = require("fs")
 

--- a/test/consistency.js
+++ b/test/consistency.js
@@ -1,5 +1,5 @@
 var tap = require("tap")
-var normalize = require("../lib/normalize")
+var normalize = require("../index")
 var path = require("path")
 var fs = require("fs")
 var _ = require("underscore")

--- a/test/github-urls.js
+++ b/test/github-urls.js
@@ -1,5 +1,5 @@
 var tap = require("tap")
-var normalize = require("../lib/normalize")
+var normalize = require("../index")
 var path = require("path")
 var fs = require("fs")
 var _ = require("underscore")

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -4,7 +4,7 @@ var path = require("path")
 
 var globals = Object.keys(global)
 
-var normalize = require("../lib/normalize")
+var normalize = require("../index")
 
 var rpjPath = path.resolve(__dirname,"./fixtures/read-package-json.json")
 tap.test("normalize some package data", function(t) {


### PR DESCRIPTION
Hi @meryn,

in order to fix https://github.com/isaacs/npm-www/issues/418 it would be really nice if I had the fixer exported to use it in npm-www package pages on repository fields of packages that are published with old npm versions, but are using the new shorthand syntax for github repositories.
