### PR TITLE
`repo` => `repository`

### DIFF
--- a/lib/typos.json
+++ b/lib/typos.json
@@ -10,6 +10,7 @@
    ,"devDepenencies": "devDependencies"
    ,"devdependencies": "devDependencies"
    ,"repostitory": "repository"
+   ,"repo": "repository"
    ,"prefereGlobal": "preferGlobal"
    ,"hompage": "homepage"
    ,"hampage": "homepage"

--- a/test/typo.js
+++ b/test/typo.js
@@ -20,6 +20,7 @@ test('typos', function(t) {
       'devDepenencies should probably be devDependencies.',
       'devdependencies should probably be devDependencies.',
       'repostitory should probably be repository.',
+      'repo should probably be repository.',
       'prefereGlobal should probably be preferGlobal.',
       'hompage should probably be homepage.',
       'hampage should probably be homepage.',
@@ -38,6 +39,7 @@ test('typos', function(t) {
             ,"devDepenencies": "devDependencies"
             ,"devdependencies": "devDependencies"
             ,"repostitory": "repository"
+            ,"repo": "repository"
             ,"prefereGlobal": "preferGlobal"
             ,"hompage": "homepage"
             ,"hampage": "homepage"


### PR DESCRIPTION
allows `repo` to be used for the `repository` field
