### PR TITLE
Move warning messages to lib/warning_messages.json

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -6,8 +6,8 @@ var url = require("url")
 var typos = require("./typos")
 var coreModuleNames = require("./core_module_names")
 var githubUserRepo = require("github-url-from-username-repo")
-var format = require('util').format
-var wmessages = require('./warning_messages.json')
+var warningMessages = require('./warning_messages.json')
+var safeFormat = require('./safe_format')
 
 var fixer = module.exports = {
   // default warning function
@@ -15,10 +15,10 @@ var fixer = module.exports = {
 
   fixRepositoryField: function(data) {
     if (data.repositories) {
-      this.warn(wmessages.repositories);
+      this.warn(warningMessages.repositories);
       data.repository = data.repositories[0]
     }
-    if (!data.repository) return this.warn(wmessages.missingRepository)
+    if (!data.repository) return this.warn(warningMessages.missingRepository)
     if (typeof data.repository === "string") {
       data.repository = {
         type: "git",
@@ -37,7 +37,7 @@ var fixer = module.exports = {
     }
 
     if (r.match(/github.com\/[^\/]+\/[^\/]+\.git\.git$/)) {
-      this.warn(format(wmessages.borkenGitUrl, r))
+      this.warn(safeFormat(warningMessages.brokenGitUrl, r))
     }
   }
 
@@ -52,12 +52,12 @@ var fixer = module.exports = {
 , fixScriptsField: function(data) {
     if (!data.scripts) return
     if (typeof data.scripts !== "object") {
-      this.warn(wmessages.nonObjectScripts)
+      this.warn(warningMessages.nonObjectScripts)
       delete data.scripts
     }
     Object.keys(data.scripts).forEach(function (k) {
       if (typeof data.scripts[k] !== "string") {
-        this.warn(wmessages.nonStringScript)
+        this.warn(warningMessages.nonStringScript)
         delete data.scripts[k]
       } else if (typos.script[k]) {
         this.warn(makeTypoWarning(k, typos.script[k], "scripts"))
@@ -68,12 +68,12 @@ var fixer = module.exports = {
 , fixFilesField: function(data) {
     var files = data.files
     if (files && !Array.isArray(files)) {
-      this.warn(wmessages.nonArrayFiles)
+      this.warn(warningMessages.nonArrayFiles)
       delete data.files
     } else if (data.files) {
       data.files = data.files.filter(function(file) {
         if (!file || typeof file !== "string") {
-          this.warn(format(wmessages.invalidFilename, file))
+          this.warn(safeFormat(warningMessages.invalidFilename, file))
           return false
         } else {
           return true
@@ -105,12 +105,12 @@ var fixer = module.exports = {
       delete data[bdd]
     }
     if (data[bd] && !Array.isArray(data[bd])) {
-      this.warn(wmessages.nonArrayBundleDependencies)
+      this.warn(warningMessages.nonArrayBundleDependencies)
       delete data[bd]
     } else if (data[bd]) {
       data[bd] = data[bd].filter(function(bd) {
         if (!bd || typeof bd !== 'string') {
-          this.warn(format(nonStringBundleDependency, bd))
+          this.warn(safeFormat(nonStringBundleDependency, bd))
           return false
         } else {
           return true
@@ -128,14 +128,14 @@ var fixer = module.exports = {
     ;['dependencies','devDependencies'].forEach(function(deps) {
       if (!(deps in data)) return
       if (!data[deps] || typeof data[deps] !== "object") {
-        this.warn(format(wmessages.nonObjectDependencies, deps))
+        this.warn(safeFormat(warningMessages.nonObjectDependencies, deps))
         delete data[deps]
         return
       }
       Object.keys(data[deps]).forEach(function (d) {
         var r = data[deps][d]
         if (typeof r !== 'string') {
-          this.warn(format(nonStringDependency, d, JSON.stringify(r)))
+          this.warn(safeFormat(nonStringDependency, d, JSON.stringify(r)))
           delete data[deps][d]
         }
       }, this)
@@ -144,7 +144,7 @@ var fixer = module.exports = {
 
 , fixModulesField: function (data) {
     if (data.modules) {
-      this.warn(wmessages.deprecatedModules)
+      this.warn(warningMessages.deprecatedModules)
       delete data.modules
     }
   }
@@ -155,11 +155,11 @@ var fixer = module.exports = {
     }
     if (data.keywords && !Array.isArray(data.keywords)) {
       delete data.keywords
-      this.warn(wmessages.nonArrayKeywords)
+      this.warn(warningMessages.nonArrayKeywords)
     } else if (data.keywords) {
       data.keywords = data.keywords.filter(function(kw) {
         if (typeof kw !== "string" || !kw) {
-          this.warn(wmessages.nonStringKeyword);
+          this.warn(warningMessages.nonStringKeyword);
           return false
         } else {
           return true
@@ -200,24 +200,24 @@ var fixer = module.exports = {
       data.name = data.name.trim()
     ensureValidName(data.name, strict)
     if (coreModuleNames.indexOf(data.name) !== -1)
-      this.warn(format(wmessages.conflictingName, data.name))
+      this.warn(safeFormat(warningMessages.conflictingName, data.name))
   }
 
 
 , fixDescriptionField: function (data) {
     if (data.description && typeof data.description !== 'string') {
-      this.warn(wmessages.nonStringDescription)
+      this.warn(warningMessages.nonStringDescription)
       delete data.description
     }
     if (data.readme && !data.description)
       data.description = extractDescription(data.readme)
       if(data.description === undefined) delete data.description;
-    if (!data.description) this.warn(wmessages.missingDescription)
+    if (!data.description) this.warn(warningMessages.missingDescription)
   }
 
 , fixReadmeField: function (data) {
     if (!data.readme) {
-      this.warn(wmessages.missingReadme)
+      this.warn(warningMessages.missingReadme)
       data.readme = "ERROR: No README data found!"
     }
   }
@@ -240,7 +240,7 @@ var fixer = module.exports = {
         else if(url.parse(data.bugs).protocol)
           data.bugs = {url: data.bugs}
         else
-          this.warn(wmessages.nonEmailUrlBugsString)
+          this.warn(warningMessages.nonEmailUrlBugsString)
       }
       else {
         bugsTypos(data.bugs, this.warn)
@@ -250,18 +250,18 @@ var fixer = module.exports = {
           if(typeof(oldBugs.url) == "string" && url.parse(oldBugs.url).protocol)
             data.bugs.url = oldBugs.url
           else
-            this.warn(wmessages.nonUrlBugsUrlField)
+            this.warn(warningMessages.nonUrlBugsUrlField)
         }
         if(oldBugs.email) {
           if(typeof(oldBugs.email) == "string" && emailRe.test(oldBugs.email))
             data.bugs.email = oldBugs.email
           else
-            this.warn(wmessages.nonEmailBugsEmailField)
+            this.warn(warningMessages.nonEmailBugsEmailField)
         }
       }
       if(!data.bugs.email && !data.bugs.url) {
         delete data.bugs
-        this.warn(wmessages.emptyNormalizedBugs)
+        this.warn(warningMessages.emptyNormalizedBugs)
       }
     }
   }
@@ -277,11 +277,11 @@ var fixer = module.exports = {
       return true
 
     if(typeof data.homepage !== "string") {
-      this.warn(wmessages.nonUrlHomepage)
+      this.warn(warningMessages.nonUrlHomepage)
       return delete data.homepage
     }
     if(!url.parse(data.homepage).protocol) {
-      this.warn(wmessages.missingProtocolHomepage)
+      this.warn(warningMessages.missingProtocolHomepage)
       data.homepage = "http://" + data.homepage
     }
   }
@@ -345,7 +345,7 @@ function depObjectify (deps, type, warn) {
     deps = deps.trim().split(/[\n\r\s\t ,]+/)
   }
   if (!Array.isArray(deps)) return deps
-  warn(format(wmessages.deprecatedArrayDependencies, type))
+  warn(safeFormat(warningMessages.deprecatedArrayDependencies, type))
   var o = {}
   deps.filter(function (d) {
     return typeof d === "string"
@@ -383,5 +383,5 @@ function makeTypoWarning (providedName, probableName, field) {
     providedName = field + "['" + providedName + "']"
     probableName = field + "['" + probableName + "']"
   }
-  return format(wmessages.typo, providedName, probableName)
+  return safeFormat(warningMessages.typo, providedName, probableName)
 }

--- a/lib/safe_format.js
+++ b/lib/safe_format.js
@@ -1,0 +1,9 @@
+var util = require('util')
+
+module.exports = function() {
+  var args = Array.prototype.slice.call(arguments, 0)
+  args.forEach(function(arg) {
+    if (!arg) throw new TypeError('Bad arguments.')
+  })
+  return util.format.apply(null, arguments)
+}

--- a/lib/warning_messages.json
+++ b/lib/warning_messages.json
@@ -1,7 +1,7 @@
 {
   "repositories": "'repositories' (plural) Not supported. Please pick one as the 'repository' field"
   ,"missingRepository": "No repository field."
-  ,"borkenGitUrl": "Probably broken git url: %s"
+  ,"brokenGitUrl": "Probably broken git url: %s"
   ,"nonObjectScripts": "scripts must be an object"
   ,"nonStringScript": "script values must be string commands"
   ,"nonArrayFiles": "Invalid 'files' member"

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -2,12 +2,11 @@ var tap = require("tap")
 var fs = require("fs")
 var path = require("path")
 
-var format = require("util").format
-
 var globals = Object.keys(global)
 
 var normalize = require("../lib/normalize")
-var wmessages = require("../lib/warning_messages.json")
+var warningMessages = require("../lib/warning_messages.json")
+var safeFormat = require("../lib/safe_format")
 
 var rpjPath = path.resolve(__dirname,"./fixtures/read-package-json.json")
 tap.test("normalize some package data", function(t) {
@@ -51,9 +50,9 @@ tap.test("empty object", function(t) {
   normalize(packageData, warn)
   t.same(packageData, expect)
   t.same(warnings, [
-    wmessages.missingDescription,
-    wmessages.missingRepository,
-    wmessages.missingReadme
+    warningMessages.missingDescription,
+    warningMessages.missingRepository,
+    warningMessages.missingReadme
   ])
   t.end()
 })
@@ -73,10 +72,10 @@ tap.test("core module name", function(t) {
   }, warn)
 
   var expect = [
-      format(wmessages.conflictingName, 'http'),
-      wmessages.nonEmailUrlBugsString,
-      wmessages.emptyNormalizedBugs,
-      wmessages.nonUrlHomepage
+      safeFormat(warningMessages.conflictingName, 'http'),
+      warningMessages.nonEmailUrlBugsString,
+      warningMessages.emptyNormalizedBugs,
+      warningMessages.nonUrlHomepage
       ]
   t.same(warnings, expect)
   t.end()
@@ -104,15 +103,15 @@ tap.test("urls required", function(t) {
   console.error(a)
 
   var expect =
-    [ wmessages.missingDescription,
-      wmessages.missingRepository,
-      wmessages.nonUrlBugsUrlField,
-      wmessages.nonEmailBugsEmailField,
-      wmessages.emptyNormalizedBugs,
-      wmessages.missingReadme,
-      wmessages.nonEmailUrlBugsString,
-      wmessages.emptyNormalizedBugs,
-      wmessages.nonUrlHomepage ]
+    [ warningMessages.missingDescription,
+      warningMessages.missingRepository,
+      warningMessages.nonUrlBugsUrlField,
+      warningMessages.nonEmailBugsEmailField,
+      warningMessages.emptyNormalizedBugs,
+      warningMessages.missingReadme,
+      warningMessages.nonEmailUrlBugsString,
+      warningMessages.emptyNormalizedBugs,
+      warningMessages.nonUrlHomepage ]
   t.same(warnings, expect)
   t.end()
 })
@@ -130,10 +129,10 @@ tap.test("homepage field must start with a protocol.", function(t) {
   console.error(a)
 
   var expect =
-    [ wmessages.missingDescription,
-      wmessages.missingRepository,
-      wmessages.missingReadme,
-      wmessages.missingProtocolHomepage ]
+    [ warningMessages.missingDescription,
+      warningMessages.missingRepository,
+      warningMessages.missingReadme,
+      warningMessages.missingProtocolHomepage ]
   t.same(warnings, expect)
   t.same(a.homepage, 'http://example.org')
   t.end()
@@ -208,9 +207,9 @@ tap.test("deprecation warning for array in dependencies fields", function(t) {
     devDependencies: [],
     optionalDependencies: []
   }, warn)
-  t.ok(~warnings.indexOf(format(wmessages.deprecatedArrayDependencies, 'dependencies')), "deprecation warning")
-  t.ok(~warnings.indexOf(format(wmessages.deprecatedArrayDependencies, 'devDependencies')), "deprecation warning")
-  t.ok(~warnings.indexOf(format(wmessages.deprecatedArrayDependencies, 'optionalDependencies')), "deprecation warning")
+  t.ok(~warnings.indexOf(safeFormat(warningMessages.deprecatedArrayDependencies, 'dependencies')), "deprecation warning")
+  t.ok(~warnings.indexOf(safeFormat(warningMessages.deprecatedArrayDependencies, 'devDependencies')), "deprecation warning")
+  t.ok(~warnings.indexOf(safeFormat(warningMessages.deprecatedArrayDependencies, 'optionalDependencies')), "deprecation warning")
   t.end()
 })
 

--- a/test/typo.js
+++ b/test/typo.js
@@ -1,10 +1,9 @@
 var test = require('tap').test
 
-var format = require("util").format
-
 var normalize = require('../')
 var typos = require('../lib/typos.json')
-var wmessages = require("../lib/warning_messages.json")
+var warningMessages = require("../lib/warning_messages.json")
+var safeFormat = require("../lib/safe_format")
 
 test('typos', function(t) {
   var warnings = []
@@ -12,10 +11,10 @@ test('typos', function(t) {
     warnings.push(m)
   }
   
-  var typoMessage = format.bind(undefined, wmessages.typo)
+  var typoMessage = safeFormat.bind(undefined, warningMessages.typo)
 
   var expect =
-    [ wmessages.missingRepository,
+    [ warningMessages.missingRepository,
       typoMessage('dependancies', 'dependencies'),
       typoMessage('dependecies', 'dependencies'),
       typoMessage('depdenencies', 'dependencies'),
@@ -61,13 +60,13 @@ test('typos', function(t) {
 
   warnings.length = 0
   var expect =
-    [ wmessages.missingDescription,
-      wmessages.missingRepository,
+    [ warningMessages.missingDescription,
+      warningMessages.missingRepository,
       typoMessage("bugs['web']", "bugs['url']"),
       typoMessage("bugs['name']", "bugs['url']"),
-      wmessages.nonUrlBugsUrlField,
-      wmessages.emptyNormalizedBugs,
-      wmessages.missingReadme ]
+      warningMessages.nonUrlBugsUrlField,
+      warningMessages.emptyNormalizedBugs,
+      warningMessages.missingReadme ]
 
   normalize({name:"name"
             ,version:"1.2.5"
@@ -77,9 +76,9 @@ test('typos', function(t) {
 
   warnings.length = 0
   var expect =
-    [ wmessages.missingDescription,
-      wmessages.missingRepository,
-      wmessages.missingReadme,
+    [ warningMessages.missingDescription,
+      warningMessages.missingRepository,
+      warningMessages.missingReadme,
       typoMessage('script', 'scripts') ]
 
   normalize({name:"name"
@@ -90,11 +89,11 @@ test('typos', function(t) {
 
   warnings.length = 0
   expect =
-    [ wmessages.missingDescription,
-      wmessages.missingRepository,
+    [ warningMessages.missingDescription,
+      warningMessages.missingRepository,
       typoMessage("scripts['server']", "scripts['start']"),
       typoMessage("scripts['tests']", "scripts['test']"),
-      wmessages.missingReadme ]
+      warningMessages.missingReadme ]
 
   normalize({name:"name"
             ,version:"1.2.5"


### PR DESCRIPTION
For the sake of refactoring and cleaner code, I moved warning messages to `lib/warning_messages.json`.

I also want to implement 'suppress' field support so users can suppress certain warning messages. In order to do so, warning messages must have a name. This commit gives (hopefully) self-describing names to warning messages.
