### PR TITLE
Fix missing undefined nonStringDependency error

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -135,7 +135,7 @@ var fixer = module.exports = {
       Object.keys(data[deps]).forEach(function (d) {
         var r = data[deps][d]
         if (typeof r !== 'string') {
-          this.warn(format(nonStringDependency, d, JSON.stringify(r)))
+          this.warn(format(warningMessages.nonStringDependency, d, JSON.stringify(r)))
           delete data[deps][d]
         }
         // "/" is not allowed as packagename for publishing, but for git-urls


### PR DESCRIPTION
npm 1.4.3 fails to install certain package configurations due to this.
