### PR TITLE
Add a CLI so you can `cat package.json | npd > package.json`

### DIFF
--- a/bin/npd.js
+++ b/bin/npd.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+var normalize = require("../lib/normalize");
+var fs = require('fs');
+var path = require('path');
+var pkg = "";
+
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('readable', function() {
+  var chunk = process.stdin.read();
+  if (chunk !== null) pkg += chunk;
+});
+
+process.stdin.on('end', function() {
+  pkg = JSON.parse(pkg);
+  normalize(pkg);
+
+  // Remove hidden/unwanted properties
+  delete pkg.readme;
+  delete pkg._id;
+
+  process.stdout.write(JSON.stringify(pkg, null, 2));
+});

--- a/bin/npd.js
+++ b/bin/npd.js
@@ -7,6 +7,13 @@ var pkg = "";
 
 process.stdin.setEncoding('utf8');
 
+if (process.stdin.isTTY) {
+  console.log("\nUsage");
+  console.log("$ cat package.json | normalize-package-data");
+  console.log("$ cat package.json | normalize-package-data > package.json\n");
+  process.exit();
+}
+
 process.stdin.on('readable', function() {
   var chunk = process.stdin.read();
   if (chunk !== null) pkg += chunk;

--- a/package.json
+++ b/package.json
@@ -20,5 +20,9 @@
     "tap": "~0.2.5",
     "underscore": "~1.4.4",
     "async": "~0.2.7"
+  },
+  "bin": {
+    "npd": "./bin/npd.js",
+    "normalize-package-data": "./bin/npd.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "async": "~0.2.7"
   },
   "bin": {
-    "npd": "./bin/npd.js",
     "normalize-package-data": "./bin/npd.js"
   }
 }


### PR DESCRIPTION
I like the idea of [cleaning up my package.json locally](https://github.com/npm/normalize-package-data#what-normalization-currently-entails) so I can learn to be a better npm citizen and write better package.json files. To this end, I've add this CLI that reads from `stdin`, normalizes, writes to `stdout`.

A few concerns:

- Maybe there's already a tool that does this?
- I gave the CLI two names: a long one that matches the package name, and a short one (npd) that's easy to type. I like this flexibility, but maybe it's Bad™
- Is there a way to detect the absence of stdin, so usage can be displayed if the command is run without having anything piped to it?