### PR TITLE
Switch to using hosted-git-info to normalize urls to have greater consistency

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -1,11 +1,10 @@
 var semver = require("semver")
-var parseGitHubURL = require("github-url-from-git")
+var hostedGitInfo = require("hosted-git-info")
 var depTypes = ["dependencies","devDependencies","optionalDependencies"]
 var extractDescription = require("./extract_description")
 var url = require("url")
 var typos = require("./typos")
 var coreModuleNames = require("./core_module_names")
-var githubUserRepo = require("github-url-from-username-repo")
 
 var fixer = module.exports = {
   // default warning function
@@ -25,12 +24,10 @@ var fixer = module.exports = {
     }
     var r = data.repository.url || ""
     if (r) {
-      var ghurl = parseGitHubURL(r)
-      if (ghurl) {
-        r = ghurl.replace(/^https?:\/\//, 'git://')
-      } else if (githubUserRepo(r)) {
-        // repo has 'user/reponame' filled in as repo
-        data.repository.url = githubUserRepo(r)
+      var hosted = hostedGitInfo.fromUrl(r)
+      if (hosted) {
+        r = data.repository.url
+          = hosted.type=="gist" ? hosted.ssh() : hosted.https()
       }
     }
 
@@ -143,11 +140,8 @@ var fixer = module.exports = {
           this.warn("nonStringDependency", d, JSON.stringify(r))
           delete data[deps][d]
         }
-        // "/" is not allowed as packagename for publishing, but for git-urls
-        // normalize shorthand-urls
-        if (githubUserRepo(data[deps][d])) {
-          data[deps][d] = 'git+' + githubUserRepo(data[deps][d])
-        }
+        var hosted = hostedGitInfo.fromUrl(data[deps][d])
+        if (hosted) data[deps][d] = "git+"+hosted.https()
       }, this)
     }, this)
   }
@@ -234,12 +228,9 @@ var fixer = module.exports = {
 
 , fixBugsField: function(data) {
     if (!data.bugs && data.repository && data.repository.url) {
-      var gh = parseGitHubURL(data.repository.url)
-      if(gh) {
-        if(gh.match(/^https:\/\/github.com\//))
-          data.bugs = {url: gh + "/issues"}
-        else // gist url
-          data.bugs = {url: gh}
+      var hosted = hostedGitInfo.fromUrl(data.repository.url)
+      if(hosted && hosted.bugs()) {
+        data.bugs = {url: hosted.bugs()}
       }
     }
     else if(data.bugs) {
@@ -278,19 +269,17 @@ var fixer = module.exports = {
 
 , fixHomepageField: function(data) {
     if (!data.homepage && data.repository && data.repository.url) {
-      var gh = parseGitHubURL(data.repository.url)
-      if (gh)
-          data.homepage = gh
-      else
-        return true
-    } else if (!data.homepage)
-      return true
+      var hosted = hostedGitInfo.fromUrl(data.repository.url)
+      if (hosted && hosted.docs()) data.homepage = hosted.docs()
+    }
+    if (!data.homepage) return
 
     if(typeof data.homepage !== "string") {
       this.warn("nonUrlHomepage")
-      return delete data.homepage
+      delete data.homepage
+      return
     }
-    if(!url.parse(data.homepage).protocol) {
+    else if(!url.parse(data.homepage).protocol) {
       this.warn("missingProtocolHomepage")
       data.homepage = "http://" + data.homepage
     }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "github-url-from-git": "^1.3.0",
-    "github-url-from-username-repo": "^1.0.0",
+    "hosted-git-info": "^1.4.0",
     "semver": "2 || 3 || 4"
   },
   "devDependencies": {

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -9,6 +9,7 @@ var warningMessages = require("../lib/warning_messages.json")
 var safeFormat = require("../lib/safe_format")
 
 var rpjPath = path.resolve(__dirname,"./fixtures/read-package-json.json")
+
 tap.test("normalize some package data", function(t) {
   var packageData = require(rpjPath)
   var warnings = []
@@ -143,7 +144,7 @@ tap.test("gist bugs url", function(t) {
     repository: "git@gist.github.com:123456.git"
   }
   normalize(d)
-  t.same(d.repository, { type: 'git', url: 'git@gist.github.com:123456.git' })
+  t.same(d.repository, { type: 'git', url: 'git@gist.github.com:/123456.git' })
   t.same(d.bugs, { url: 'https://gist.github.com/123456' })
   t.end();
 });
@@ -151,21 +152,21 @@ tap.test("gist bugs url", function(t) {
 tap.test("singularize repositories", function(t) {
   var d = {repositories:["git@gist.github.com:123456.git"]}
   normalize(d)
-  t.same(d.repository, { type: 'git', url: 'git@gist.github.com:123456.git' })
+  t.same(d.repository, { type: 'git', url: 'git@gist.github.com:/123456.git' })
   t.end()
 });
 
 tap.test("treat visionmedia/express as github repo", function(t) {
   var d = {repository: {type: "git", url: "visionmedia/express"}}
   normalize(d)
-  t.same(d.repository, { type: "git", url: "https://github.com/visionmedia/express" })
+  t.same(d.repository, { type: "git", url: "https://github.com/visionmedia/express.git" })
   t.end()
 });
 
 tap.test("treat isaacs/node-graceful-fs as github repo", function(t) {
   var d = {repository: {type: "git", url: "isaacs/node-graceful-fs"}}
   normalize(d)
-  t.same(d.repository, { type: "git", url: "https://github.com/isaacs/node-graceful-fs" })
+  t.same(d.repository, { type: "git", url: "https://github.com/isaacs/node-graceful-fs.git" })
   t.end()
 });
 
@@ -174,7 +175,7 @@ tap.test("homepage field will set to github url if repository is a github repo",
   normalize(a={
     repository: { type: "git", url: "https://github.com/isaacs/node-graceful-fs" }
   })
-  t.same(a.homepage, 'https://github.com/isaacs/node-graceful-fs')
+  t.same(a.homepage, 'https://github.com/isaacs/node-graceful-fs#readme')
   t.end()
 })
 
@@ -192,14 +193,14 @@ tap.test("homepage field will set to github gist url if repository is a shorthan
   normalize(a={
     repository: { type: "git", url: "sindresorhus/chalk" }
   })
-  t.same(a.homepage, 'https://github.com/sindresorhus/chalk')
+  t.same(a.homepage, 'https://github.com/sindresorhus/chalk#readme')
   t.end()
 })
 
 tap.test("treat isaacs/node-graceful-fs as github repo in dependencies", function(t) {
   var d = {dependencies: {"node-graceful-fs": "isaacs/node-graceful-fs"}}
   normalize(d)
-  t.same(d.dependencies, {"node-graceful-fs": "git+https://github.com/isaacs/node-graceful-fs" })
+  t.same(d.dependencies, {"node-graceful-fs": "git+https://github.com/isaacs/node-graceful-fs.git" })
   t.end()
 });
 


### PR DESCRIPTION
This allows it to understand urls the same way npm-package-arg does, using the same code. I believe this also addresses #14. This also fixes #51.

It does do some weird things to maintain current behavior, maybe it shouldn't:

1. It changes the protocol for github dependencies from https to git+https.
2. Using ssh repository paths for gists *only*.

Behavior changed:

1. Repositories now use https:// urls, not git:// urls.
2. ssh paths now start with a slash for gists, eg, git@gist.github.com:/123456 – this is changed to match Githubs current defaults. (Presumably to remove parsing ambiguity for things that thought the number was a port.)
3. https repository urls now get a .git on the end
4. homepage urls derived from github repositories now link to #readme (which is consistent with how `npm docs` uses the homepage field)