### PR TITLE
Do not warn on script entry if its idiomatic counterpart is also present

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -57,7 +57,7 @@ var fixer = module.exports = {
       if (typeof data.scripts[k] !== "string") {
         this.warn("nonStringScript")
         delete data.scripts[k]
-      } else if (typos.script[k]) {
+      } else if (typos.script[k] && !data.scripts[typos.script[k]]) {
         this.warn("typo", k, typos.script[k], "scripts")
       }
     }, this)

--- a/test/typo.js
+++ b/test/typo.js
@@ -102,6 +102,19 @@ test('typos', function(t) {
   t.same(warnings, expect)
 
   warnings.length = 0
+  expect =
+    [ warningMessages.missingDescription,
+      warningMessages.missingRepository,
+      warningMessages.missingReadme ]
+
+  normalize({name:"name"
+            ,version:"1.2.5"
+            ,scripts:{server:"start",tests:"test"
+                     ,start:"start",test:"test"}}, warn)
+
+  t.same(warnings, expect)
+
+  warnings.length = 0
   expect = []
 
   normalize({private: true


### PR DESCRIPTION
If package.json defines both `start` and `server` scripts npm prints the warning message:

```
scripts['server'] should probably be scripts['start']
```

Since `start` script is also defined this message does not help and makes no sense to the user.

This patch makes npm print message only if `server` is defined and `start` is not (same for `tests` and `test`). npm scripts are used to run arbitrary tasks so certain names shouldn't be discouraged with no good reason for it.