### PR TITLE
remove normalization of GitHub shorthand for dependencies

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -143,11 +143,6 @@ var fixer = module.exports = {
           this.warn("nonStringDependency", d, JSON.stringify(r))
           delete data[deps][d]
         }
-        // "/" is not allowed as packagename for publishing, but for git-urls
-        // normalize shorthand-urls
-        if (githubUserRepo(data[deps][d])) {
-          data[deps][d] = 'git+' + githubUserRepo(data[deps][d])
-        }
       }, this)
     }, this)
   }

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -196,10 +196,11 @@ tap.test("homepage field will set to github gist url if repository is a shorthan
   t.end()
 })
 
-tap.test("treat isaacs/node-graceful-fs as github repo in dependencies", function(t) {
+tap.test("don't treat isaacs/node-graceful-fs as GitHub repo in dependencies", function(t) {
+  t.comment("GitHub shorthand is handled by npm's cache, so normalization leaves it alone")
   var d = {dependencies: {"node-graceful-fs": "isaacs/node-graceful-fs"}}
   normalize(d)
-  t.same(d.dependencies, {"node-graceful-fs": "git+https://github.com/isaacs/node-graceful-fs" })
+  t.same(d.dependencies, {"node-graceful-fs": "isaacs/node-graceful-fs" })
   t.end()
 });
 


### PR DESCRIPTION
This is better handled in one place, in the caching code (the fact that it's in two places is the ultimate cause for npm/npm#7630 and npm/npm#7302).

This is a breaking change, and therefore semver-major.

**r**: @iarna 
**r**: @isaacs (if he's available / feels like it)