### PR TITLE
Switch to using hosted-git-info to normalize urls to have greater consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ If the supplied data has an invalid name or version vield, `normalizeData` will 
 * If `bundledDependencies` field (a typo) exists and `bundleDependencies` field does not, `bundledDependencies` will get renamed to `bundleDependencies`.
 * If the value of any of the dependencies fields  (`dependencies`, `devDependencies`, `optionalDependencies`) is a string, it gets converted into an object with familiar `name=>value` pairs.
 * The values in `optionalDependencies` get added to `dependencies`. The `optionalDependencies` array is left untouched.
+* As of v2: Dependencies that point at known hosted git providers (currently: github, bitbucket, gitlab) will have their URLs canonicalized, but protocols will be preserved.
+* As of v2: Dependencies that use shortcuts for hosted git providers (`org/proj`, `github:org/proj`, `bitbucket:org/proj`, `gitlab:org/proj`, `gist:docid`) will have the shortcut left in place. (In the case of github, the `org/proj` form will be expanded to `github:org/proj`.) THIS MARKS A BREAKING CHANGE FROM V1, where the shorcut was previously expanded to a URL.
 * If `description` field does not exist, but `readme` field does, then (more or less) the first paragraph of text that's found in the readme is taken as value for `description`.
 * If `repository` field is a string, it will become an object with `url` set to the original string value, and `type` set to `"git"`.
-* If `repository.url` is not a valid url, but in the style of "[owner-name]/[repo-name]", `repository.url` will be set to git://github.com/[owner-name]/[repo-name]
+* If `repository.url` is not a valid url, but in the style of "[owner-name]/[repo-name]", `repository.url` will be set to https://github.com/[owner-name]/[repo-name]
 * If `bugs` field is a string, the value of `bugs` field is changed into an object with `url` set to the original string value.
 * If `bugs` field does not exist, but `repository` field points to a repository hosted on GitHub, the value of the `bugs` field gets set to an url in the form of https://github.com/[owner-name]/[repo-name]/issues . If the repository field points to a GitHub Gist repo url, the associated http url is chosen.
 * If `bugs` field is an object, the resulting value only has email and url properties. If email and url properties are not strings, they are ignored. If no valid values for either email or url is found, bugs field will be removed.

--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -1,11 +1,10 @@
 var semver = require("semver")
-var parseGitHubURL = require("github-url-from-git")
+var hostedGitInfo = require("hosted-git-info")
 var depTypes = ["dependencies","devDependencies","optionalDependencies"]
 var extractDescription = require("./extract_description")
 var url = require("url")
 var typos = require("./typos")
 var coreModuleNames = require("./core_module_names")
-var githubUserRepo = require("github-url-from-username-repo")
 
 var fixer = module.exports = {
   // default warning function
@@ -25,12 +24,10 @@ var fixer = module.exports = {
     }
     var r = data.repository.url || ""
     if (r) {
-      var ghurl = parseGitHubURL(r)
-      if (ghurl) {
-        r = ghurl.replace(/^https?:\/\//, 'git://')
-      } else if (githubUserRepo(r)) {
-        // repo has 'user/reponame' filled in as repo
-        data.repository.url = githubUserRepo(r)
+      var hosted = hostedGitInfo.fromUrl(r)
+      if (hosted) {
+        r = data.repository.url
+          = hosted.getDefaultRepresentation() == "shortcut" ? hosted.https() : hosted.toString()
       }
     }
 
@@ -143,11 +140,8 @@ var fixer = module.exports = {
           this.warn("nonStringDependency", d, JSON.stringify(r))
           delete data[deps][d]
         }
-        // "/" is not allowed as packagename for publishing, but for git-urls
-        // normalize shorthand-urls
-        if (githubUserRepo(data[deps][d])) {
-          data[deps][d] = 'git+' + githubUserRepo(data[deps][d])
-        }
+        var hosted = hostedGitInfo.fromUrl(data[deps][d])
+        if (hosted) data[deps][d] = hosted.toString()
       }, this)
     }, this)
   }
@@ -234,12 +228,9 @@ var fixer = module.exports = {
 
 , fixBugsField: function(data) {
     if (!data.bugs && data.repository && data.repository.url) {
-      var gh = parseGitHubURL(data.repository.url)
-      if(gh) {
-        if(gh.match(/^https:\/\/github.com\//))
-          data.bugs = {url: gh + "/issues"}
-        else // gist url
-          data.bugs = {url: gh}
+      var hosted = hostedGitInfo.fromUrl(data.repository.url)
+      if(hosted && hosted.bugs()) {
+        data.bugs = {url: hosted.bugs()}
       }
     }
     else if(data.bugs) {
@@ -278,13 +269,10 @@ var fixer = module.exports = {
 
 , fixHomepageField: function(data) {
     if (!data.homepage && data.repository && data.repository.url) {
-      var gh = parseGitHubURL(data.repository.url)
-      if (gh)
-          data.homepage = gh
-      else
-        return true
-    } else if (!data.homepage)
-      return true
+      var hosted = hostedGitInfo.fromUrl(data.repository.url)
+      if (hosted && hosted.docs()) data.homepage = hosted.docs()
+    }
+    if (!data.homepage) return
 
     if(typeof data.homepage !== "string") {
       this.warn("nonUrlHomepage")

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "github-url-from-git": "^1.3.0",
-    "github-url-from-username-repo": "^1.0.0",
+    "hosted-git-info": "^2.0.2",
     "semver": "2 || 3 || 4"
   },
   "devDependencies": {

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -9,6 +9,7 @@ var warningMessages = require("../lib/warning_messages.json")
 var safeFormat = require("../lib/safe_format")
 
 var rpjPath = path.resolve(__dirname,"./fixtures/read-package-json.json")
+
 tap.test("normalize some package data", function(t) {
   var packageData = require(rpjPath)
   var warnings = []
@@ -143,7 +144,7 @@ tap.test("gist bugs url", function(t) {
     repository: "git@gist.github.com:123456.git"
   }
   normalize(d)
-  t.same(d.repository, { type: 'git', url: 'git@gist.github.com:123456.git' })
+  t.same(d.repository, { type: 'git', url: 'git+ssh://git@gist.github.com/123456.git' })
   t.same(d.bugs, { url: 'https://gist.github.com/123456' })
   t.end();
 });
@@ -151,21 +152,21 @@ tap.test("gist bugs url", function(t) {
 tap.test("singularize repositories", function(t) {
   var d = {repositories:["git@gist.github.com:123456.git"]}
   normalize(d)
-  t.same(d.repository, { type: 'git', url: 'git@gist.github.com:123456.git' })
+  t.same(d.repository, { type: 'git', url: 'git+ssh://git@gist.github.com/123456.git' })
   t.end()
 });
 
 tap.test("treat visionmedia/express as github repo", function(t) {
   var d = {repository: {type: "git", url: "visionmedia/express"}}
   normalize(d)
-  t.same(d.repository, { type: "git", url: "https://github.com/visionmedia/express" })
+  t.same(d.repository, { type: "git", url: "https://github.com/visionmedia/express.git" })
   t.end()
 });
 
 tap.test("treat isaacs/node-graceful-fs as github repo", function(t) {
   var d = {repository: {type: "git", url: "isaacs/node-graceful-fs"}}
   normalize(d)
-  t.same(d.repository, { type: "git", url: "https://github.com/isaacs/node-graceful-fs" })
+  t.same(d.repository, { type: "git", url: "https://github.com/isaacs/node-graceful-fs.git" })
   t.end()
 });
 
@@ -174,7 +175,7 @@ tap.test("homepage field will set to github url if repository is a github repo",
   normalize(a={
     repository: { type: "git", url: "https://github.com/isaacs/node-graceful-fs" }
   })
-  t.same(a.homepage, 'https://github.com/isaacs/node-graceful-fs')
+  t.same(a.homepage, 'https://github.com/isaacs/node-graceful-fs#readme')
   t.end()
 })
 
@@ -192,14 +193,14 @@ tap.test("homepage field will set to github gist url if repository is a shorthan
   normalize(a={
     repository: { type: "git", url: "sindresorhus/chalk" }
   })
-  t.same(a.homepage, 'https://github.com/sindresorhus/chalk')
+  t.same(a.homepage, 'https://github.com/sindresorhus/chalk#readme')
   t.end()
 })
 
-tap.test("treat isaacs/node-graceful-fs as github repo in dependencies", function(t) {
+tap.test("don't mangle github shortcuts in dependencies", function(t) {
   var d = {dependencies: {"node-graceful-fs": "isaacs/node-graceful-fs"}}
   normalize(d)
-  t.same(d.dependencies, {"node-graceful-fs": "git+https://github.com/isaacs/node-graceful-fs" })
+  t.same(d.dependencies, {"node-graceful-fs": "github:isaacs/node-graceful-fs" })
   t.end()
 });
 


### PR DESCRIPTION

* [x] Document breaking change, due to github shortcuts in dependencies no longer being URLed