### PR TITLE
Add "BSD-2-Clause" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "author": "Meryn Stol <merynstol@gmail.com>",
   "description": "Normalizes data that can be found in package.json files.",
+  "license": "BSD-2-Clause",
   "repository": {
     "type": "git",
     "url": "git://github.com/npm/normalize-package-data.git"


### PR DESCRIPTION
This PR is for a single, tiny commit adding the SPDX identifier for the 2-clause BSD license, `"BSD-2-Clause"`, to package.json. The change conforms to npm's guidelines for package metadata via `npm help 7 package.json`.