### PR TITLE
Validate license fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ If `name` field is given, the value of the name field must be a string. The stri
 
 If `version` field is given, the value of the version field must be a valid *semver* string, as determined by the `semver.valid` method. See [documentation for the semver module](https://github.com/isaacs/node-semver).
 
+### Rules for license field
+
+The `license` field should be a valid *SDPDX license expression* string, as determined by the `spdx.valid` method. See [documentation for the spdx module](https://github.com/kemitchell/spdx.js).
+
 ## Credits
 
 This package contains code based on read-package-json written by Isaac Z. Schlueter. Used with permisson.

--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -1,4 +1,5 @@
 var semver = require("semver")
+var spdx = require('spdx');
 var hostedGitInfo = require("hosted-git-info")
 var depTypes = ["dependencies","devDependencies","optionalDependencies"]
 var extractDescription = require("./extract_description")
@@ -281,6 +282,18 @@ var fixer = module.exports = {
     if(!url.parse(data.homepage).protocol) {
       this.warn("missingProtocolHomepage")
       data.homepage = "http://" + data.homepage
+    }
+  }
+
+, fixLicenseField: function(data) {
+    if (!data.license) {
+      return this.warn("missingLicense")
+    } else if (
+      typeof(data.license) !== 'string' ||
+      data.license.length < 1 ||
+      !spdx.valid(data.license)
+    ) {
+      this.warn("nonSPDXLicense")
     }
   }
 }

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -4,7 +4,7 @@ var fixer = require("./fixer")
 var makeWarning = require("./make_warning")
 
 var fieldsToFix = ['name','version','description','repository','modules','scripts'
-                  ,'files','bin','man','bugs','keywords','readme','homepage']
+                  ,'files','bin','man','bugs','keywords','readme','homepage','license']
 var otherThingsToFix = ['dependencies','people', 'typos']
 
 var thingsToFix = fieldsToFix.map(function(fieldName) { 

--- a/lib/warning_messages.json
+++ b/lib/warning_messages.json
@@ -19,11 +19,13 @@
   ,"nonStringDescription": "'description' field should be a string"
   ,"missingDescription": "No description"
   ,"missingReadme": "No README data"
+  ,"missingLicense": "No license field."
   ,"nonEmailUrlBugsString": "Bug string field must be url, email, or {email,url}"
   ,"nonUrlBugsUrlField": "bugs.url field must be a string url. Deleted."
   ,"nonEmailBugsEmailField": "bugs.email field must be a string email. Deleted."
   ,"emptyNormalizedBugs": "Normalized value of bugs field is an empty object. Deleted."
   ,"nonUrlHomepage": "homepage field must be a string url. Deleted."
+  ,"nonSPDXLicense": "license should be a valid SPDX license expression"
   ,"missingProtocolHomepage": "homepage field must start with a protocol."
   ,"typo": "%s should probably be %s."
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "hosted-git-info": "^2.0.2",
-    "semver": "2 || 3 || 4"
+    "semver": "2 || 3 || 4",
+    "spdx": "^0.4.0"
   },
   "devDependencies": {
     "tap": "~0.2.5",

--- a/test/fixtures/read-package-json.json
+++ b/test/fixtures/read-package-json.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "git://github.com/isaacs/read-package-json.git"
   },
+  "license": "MIT",
   "main": "read-json.js",
   "scripts": {
     "test": "tap test/*.js"

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -53,7 +53,8 @@ tap.test("empty object", function(t) {
   t.same(warnings, [
     warningMessages.missingDescription,
     warningMessages.missingRepository,
-    warningMessages.missingReadme
+    warningMessages.missingReadme,
+    warningMessages.missingLicense
   ])
   t.end()
 })
@@ -76,7 +77,8 @@ tap.test("core module name", function(t) {
       safeFormat(warningMessages.conflictingName, 'http'),
       warningMessages.nonEmailUrlBugsString,
       warningMessages.emptyNormalizedBugs,
-      warningMessages.nonUrlHomepage
+      warningMessages.nonUrlHomepage,
+      warningMessages.missingLicense
       ]
   t.same(warnings, expect)
   t.end()
@@ -110,9 +112,11 @@ tap.test("urls required", function(t) {
       warningMessages.nonEmailBugsEmailField,
       warningMessages.emptyNormalizedBugs,
       warningMessages.missingReadme,
+      warningMessages.missingLicense,
       warningMessages.nonEmailUrlBugsString,
       warningMessages.emptyNormalizedBugs,
-      warningMessages.nonUrlHomepage ]
+      warningMessages.nonUrlHomepage,
+      warningMessages.missingLicense]
   t.same(warnings, expect)
   t.end()
 })
@@ -133,9 +137,31 @@ tap.test("homepage field must start with a protocol.", function(t) {
     [ warningMessages.missingDescription,
       warningMessages.missingRepository,
       warningMessages.missingReadme,
-      warningMessages.missingProtocolHomepage ]
+      warningMessages.missingProtocolHomepage,
+      warningMessages.missingLicense]
   t.same(warnings, expect)
   t.same(a.homepage, 'http://example.org')
+  t.end()
+})
+
+tap.test("license field should be a valid SPDX expression", function(t) {
+  var warnings = []
+  function warn(w) {
+    warnings.push(w)
+  }
+  var a
+  normalize(a={
+    license: 'Apache 2'
+  }, warn)
+
+  console.error(a)
+
+  var expect =
+    [ warningMessages.missingDescription,
+      warningMessages.missingRepository,
+      warningMessages.missingReadme,
+      warningMessages.nonSPDXLicense]
+  t.same(warnings, expect)
   t.end()
 })
 

--- a/test/typo.js
+++ b/test/typo.js
@@ -15,6 +15,7 @@ test('typos', function(t) {
 
   var expect =
     [ warningMessages.missingRepository,
+      warningMessages.missingLicense,
       typoMessage('dependancies', 'dependencies'),
       typoMessage('dependecies', 'dependencies'),
       typoMessage('depdenencies', 'dependencies'),
@@ -66,7 +67,8 @@ test('typos', function(t) {
       typoMessage("bugs['name']", "bugs['url']"),
       warningMessages.nonUrlBugsUrlField,
       warningMessages.emptyNormalizedBugs,
-      warningMessages.missingReadme ]
+      warningMessages.missingReadme,
+      warningMessages.missingLicense]
 
   normalize({name:"name"
             ,version:"1.2.5"
@@ -79,6 +81,7 @@ test('typos', function(t) {
     [ warningMessages.missingDescription,
       warningMessages.missingRepository,
       warningMessages.missingReadme,
+      warningMessages.missingLicense,
       typoMessage('script', 'scripts') ]
 
   normalize({name:"name"
@@ -93,7 +96,8 @@ test('typos', function(t) {
       warningMessages.missingRepository,
       typoMessage("scripts['server']", "scripts['start']"),
       typoMessage("scripts['tests']", "scripts['test']"),
-      warningMessages.missingReadme ]
+      warningMessages.missingReadme,
+      warningMessages.missingLicense]
 
   normalize({name:"name"
             ,version:"1.2.5"
@@ -105,7 +109,8 @@ test('typos', function(t) {
   expect =
     [ warningMessages.missingDescription,
       warningMessages.missingRepository,
-      warningMessages.missingReadme ]
+      warningMessages.missingReadme,
+      warningMessages.missingLicense]
 
   normalize({name:"name"
             ,version:"1.2.5"


### PR DESCRIPTION
This PR adds new warnings about the `"license"` field:

0. when there is no "`license`" field (including when `"licenses"` is used instead of `"license"`)
0. when the value of the `"license"` field is not a valid SPDX license expression string per [kemitchell/spdx.js][spdx.js]'s implementation of the most recent standard draft, [beta draft 0.98][spec].

It addresses many concerns in npm/npm#6241 and npm/npm#4473.

I will be happy to make additional commits (or force-push commits) as needed to make this PR easy to merge. I've tried to conform to existing style, structure, and organization; please let me know what I've missed.

A few notes:

0. [spdx.js][spdx.js] is a brand new package. The [draft specification][spec] includes an ABNF grammar, but I found I had to make changes to support all of the examples in the draft and some common-sense variations. The test suite (embedded in the README) includes all the examples from the spec, plus a few more. Any help "torture testing" would be much appreciated.

0. SPDX license expressions support complex conjunction and disjunction, e.g. `(Apache-2.0 OR GPL-3.0+)`, which can describe multiply-licensed projects. It also supports `LicenseRef-X` syntax for licenses that don't yet have standard identifiers.

[spdx.js]: http://github.com/kemitchell/spdx.js
[spec]: http://spdx.org/SPDX-specifications/spdx-version-2.0

Why should anyone care? Behold:
- [a list showing 561 of the current 1008 most-depended-upon packages do not have guidelines-approved SPDX-string license properties](https://gist.github.com/kemitchell/5496ae642e08911f12f8)
- [a population study of license properties of all packages](https://gist.github.com/kemitchell/5496ae642e08911f12f8), showing non-SPDX strings like "BSD", "Apache 2.0", and "GPLv3" are very popular, though no string license property at all is by far the largest single sub-population. There are over 800 values total, normalizing for letter case, from the amusing "TALK TO THE LEGAL DEPARTMENT" to the asinine and unwelcome "MOTHER'S TITS". Someone in npm sales should talk to Totem Labs about private modules!

Many thanks to the @maxogden and the [dat](http://dat-data.com/) team for making the above possible, and especially to @mafintosh for [dat-npm](https://github.com/mafintosh/dat-npm). Tips of my hat to @hughsk, @wercker and @substack for inspiring conversation.

@othiym23 mentioned that I should also look at [init-package-json](https://github.com/npm/init-package-json). I have done some additional work on [a function for rules-based estimation of which SPDX identifier was intended by an invalid license string](https://github.com/kemitchell/spdx-correct.js) that may be useful here or there or both. For now, I'm using it to make automated PRs to errant package authors, mostly to raise awareness.