### PR TITLE
Apply revised license metadata guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If `version` field is given, the value of the version field must be a valid *sem
 
 ### Rules for license field
 
-The `license` field should be a valid *SDPDX license expression* string, as determined by the `spdx.valid` method. See [documentation for the spdx module](https://github.com/kemitchell/spdx.js).
+The `license` field should be a valid *SDPDX license expression* or one of the special values allowed by [validate-npm-package-license](https://npmjs.com/packages/validate-npm-package-license). See [documentation for the license field in package.json](https://docs.npmjs.com/files/package.json#license).
 
 ## Credits
 

--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -1,5 +1,5 @@
 var semver = require("semver")
-var spdx = require('spdx');
+var validateLicense = require('validate-npm-package-license');
 var hostedGitInfo = require("hosted-git-info")
 var depTypes = ["dependencies","devDependencies","optionalDependencies"]
 var extractDescription = require("./extract_description")
@@ -292,12 +292,16 @@ var fixer = module.exports = {
 , fixLicenseField: function(data) {
     if (!data.license) {
       return this.warn("missingLicense")
-    } else if (
-      typeof(data.license) !== 'string' ||
-      data.license.length < 1 ||
-      !spdx.valid(data.license)
-    ) {
-      this.warn("nonSPDXLicense")
+    } else{
+      if (
+        typeof(data.license) !== 'string' ||
+        data.license.length < 1
+      ) {
+        this.warn("invalidLicense")
+      } else {
+        if (!validateLicense(data.license).validForNewPackages)
+          this.warn("invalidLicense")
+      }
     }
   }
 }

--- a/lib/warning_messages.json
+++ b/lib/warning_messages.json
@@ -25,7 +25,7 @@
   ,"nonEmailBugsEmailField": "bugs.email field must be a string email. Deleted."
   ,"emptyNormalizedBugs": "Normalized value of bugs field is an empty object. Deleted."
   ,"nonUrlHomepage": "homepage field must be a string url. Deleted."
-  ,"nonSPDXLicense": "license should be a valid SPDX license expression"
+  ,"invalidLicense": "license should be a valid SPDX license expression"
   ,"missingProtocolHomepage": "homepage field must start with a protocol."
   ,"typo": "%s should probably be %s."
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "hosted-git-info": "^2.0.2",
     "semver": "2 || 3 || 4",
-    "spdx": "^0.4.0"
+    "validate-npm-package-license": "^2.0.0"
   },
   "devDependencies": {
     "async": "~0.9.0",

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -160,7 +160,7 @@ tap.test("license field should be a valid SPDX expression", function(t) {
     [ warningMessages.missingDescription,
       warningMessages.missingRepository,
       warningMessages.missingReadme,
-      warningMessages.nonSPDXLicense]
+      warningMessages.invalidLicense]
   t.same(warnings, expect)
   t.end()
 })


### PR DESCRIPTION
Implements the revisions discussed in npm/npm#8557. Removes spdx as a direct dependency, using instead validate-npm-package-license, as does init-package-json. 

kemitchell/validate-npm-package-license.js#1 (forthcoming version 2.0.0) will check both for valid SPDX and the new "magic" values for no license and reference to a top-level license file in the package. This PR should not merge until 2.0.0 is published, and will fail 404 off the registry until then.

Sorry for the barrage of PRs. Hopefully in the distant future when some other change is required, it will pay off to have all the npm-specific SPDX language centralized in validate-npm-package-license.