### PR TITLE
Intuit bin name from string correctly for scoped packages

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -83,7 +83,12 @@ var fixer = module.exports = {
     if (!data.bin) return;
     if (typeof data.bin === "string") {
       var b = {}
-      b[data.name] = data.bin
+      var match
+      if (match = data.name.match(/^@[^/]+[/](.*)$/)) {
+        b[match[1]] = data.bin
+      } else {
+        b[data.name] = data.bin
+      }
       data.bin = b
     }
   }

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -2,8 +2,6 @@ var tap = require("tap")
 var fs = require("fs")
 var path = require("path")
 
-var globals = Object.keys(global)
-
 var normalize = require("../lib/normalize")
 var warningMessages = require("../lib/warning_messages.json")
 var safeFormat = require("../lib/safe_format")
@@ -244,10 +242,5 @@ tap.test("deprecation warning for array in dependencies fields", function(t) {
   t.ok(~warnings.indexOf(safeFormat(warningMessages.deprecatedArrayDependencies, 'dependencies')), "deprecation warning")
   t.ok(~warnings.indexOf(safeFormat(warningMessages.deprecatedArrayDependencies, 'devDependencies')), "deprecation warning")
   t.ok(~warnings.indexOf(safeFormat(warningMessages.deprecatedArrayDependencies, 'optionalDependencies')), "deprecation warning")
-  t.end()
-})
-
-tap.test('no new globals', function(t) {
-  t.same(Object.keys(global), globals)
   t.end()
 })

--- a/test/scoped.js
+++ b/test/scoped.js
@@ -1,6 +1,7 @@
 var test = require("tap").test
 
 var fixNameField = require("../lib/fixer.js").fixNameField
+var fixBinField = require("../lib/fixer.js").fixBinField
 
 test("a simple scoped module has a valid name", function (t) {
   var data = {name : "@org/package"}
@@ -47,5 +48,12 @@ test("'@/package' is not a valid name", function (t) {
     fixNameField({name : "@/package"}, false)
   }, "blows up as expected")
 
+  t.end()
+})
+
+test("name='@org/package', bin='bin.js' is bin={package:'bin.js'}", function (t) {
+  var obj = {name : "@org/package", bin: "bin.js"}
+  fixBinField(obj)
+  t.isDeeply(obj.bin, {package: 'bin.js'})
   t.end()
 })


### PR DESCRIPTION
Installing a scoped module w/ a string `bin` field would result in a binary named `@scope/package`, which is impossible to call without an absolute path, which useless to basically everyone. This changes the default to be just `package`. If it conflicts w/ a non-scoped package, `npm@3` will handle the conflict in the usual ways, and the package owner can always explicitly set the bin name to whatever it is they want.
