### PR TITLE
don't warn on missing protocol in `homepage` field

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -289,7 +289,6 @@ var fixer = module.exports = {
       return delete data.homepage
     }
     if(!url.parse(data.homepage).protocol) {
-      this.warn("missingProtocolHomepage")
       data.homepage = "http://" + data.homepage
     }
   }

--- a/lib/warning_messages.json
+++ b/lib/warning_messages.json
@@ -26,6 +26,5 @@
   ,"emptyNormalizedBugs": "Normalized value of bugs field is an empty object. Deleted."
   ,"nonUrlHomepage": "homepage field must be a string url. Deleted."
   ,"invalidLicense": "license should be a valid SPDX license expression"
-  ,"missingProtocolHomepage": "homepage field must start with a protocol."
   ,"typo": "%s should probably be %s."
 }

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -135,7 +135,6 @@ tap.test("homepage field must start with a protocol.", function(t) {
     [ warningMessages.missingDescription,
       warningMessages.missingRepository,
       warningMessages.missingReadme,
-      warningMessages.missingProtocolHomepage,
       warningMessages.missingLicense]
   t.same(warnings, expect)
   t.same(a.homepage, 'http://example.org')


### PR DESCRIPTION
I don't see why it's a warning when it's just normalized like everything else. I would like to keep my package.json minimal by not specifying a protocol.

From the readme:

> If the url in the `homepage` field does not specify a protocol, then http is assumed. For example, `myproject.org` will be changed to `http://myproject.org`.

With a warning this normalization is unusable...
