### PR TITLE
Use peoplestring-* packages with new work-made-for-hire syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If the supplied data has an invalid name or version vield, `normalizeData` will 
 * If `bin` field is a string, then `bin` field will become an object with `name` set to the value of the `name` field, and `bin` set to the original string value.
 * If `man` field is a string, it will become an array with the original string as its sole member.
 * If `keywords` field is string, it is considered to be a list of keywords separated by one or more white-space characters. It gets converted to an array by splitting on `\s+`.
-* All people fields (`author`, `maintainers`, `contributors`) get converted into objects with name, email and url properties.
+* All people fields (`author`, `maintainers`, `contributors`) get converted into objects with name, email, url, and for properties.
 * If `bundledDependencies` field (a typo) exists and `bundleDependencies` field does not, `bundledDependencies` will get renamed to `bundleDependencies`.
 * If the value of any of the dependencies fields  (`dependencies`, `devDependencies`, `optionalDependencies`) is a string, it gets converted into an object with familiar `name=>value` pairs.
 * The values in `optionalDependencies` get added to `dependencies`. The `optionalDependencies` array is left untouched.

--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -6,6 +6,8 @@ var depTypes = ["dependencies","devDependencies","optionalDependencies"]
 var extractDescription = require("./extract_description")
 var url = require("url")
 var typos = require("./typos")
+var peoplestringParse = require('peoplestring-parse')
+var peoplestringStringify = require('peoplestring-stringify')
 
 var fixer = module.exports = {
   // default warning function
@@ -348,24 +350,12 @@ function modifyPeople (data, fn) {
 
 function unParsePerson (person) {
   if (typeof person === "string") return person
-  var name = person.name || ""
-  var u = person.url || person.web
-  var url = u ? (" ("+u+")") : ""
-  var e = person.email || person.mail
-  var email = e ? (" <"+e+">") : ""
-  return name+email+url
+  else return peoplestringStringify(person)
 }
 
 function parsePerson (person) {
   if (typeof person !== "string") return person
-  var name = person.match(/^([^\(<]+)/)
-  var url = person.match(/\(([^\)]+)\)/)
-  var email = person.match(/<([^>]+)>/)
-  var obj = {}
-  if (name && name[0].trim()) obj.name = name[0].trim()
-  if (email) obj.email = email[1];
-  if (url) obj.url = url[1];
-  return obj
+  else return peoplestringParse(person)
 }
 
 function addOptionalDepsToDeps (data, warn) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "hosted-git-info": "^2.1.4",
     "is-builtin-module": "^1.0.0",
+    "peoplestring-parse": "^2.0.0",
+    "peoplestring-stringify": "^1.0.0",
     "semver": "2 || 3 || 4 || 5",
     "validate-npm-package-license": "^3.0.1"
   },


### PR DESCRIPTION
This pull adds two new dependencies that collectively implement parsing and stringification for "people" strings like

```
Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com)
```

The reason for pulling out the packages is twofold:
1. Add some dedicated tests and address a few edge cases.
2. Add syntax for companies that authors and contributors are working for, to aid in license audit and analysis. The new syntax looks like:
   
   `Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com) [Some Big, Inc.]`
   
   The new bit is in square brackets.

Without getting too far into the legal weeds, under U.S. law, the issue is "work made for hire". In a nutshell, authors get copyright in their work by default. But there is an exception when an author is employed to do the work, or has a contract to make "work made for hire". There are also contractors who assign to their work to their clients and call this "work for hire". Ownership of copyright ends up with the employer or contract client.

Of course, that's just a rough generalization. Folks should talk to lawyers whenever who-owns-what really matters. Those who'd like to do a bit more reading on their own might start with [The United States Copyright Office's circular on topic](http://copyright.gov/circs/circ09.pdf).

So the idea behind the new syntax is that if Karli Kane, engineer for hot new social media sensation InFace, gets permission to publish their "panacea" framework on npm, Karli can do:

``` json
{
  "package": "panacea-framework",
  "author": "Karli Kane <karli@inface.com> [InFace, Inc.]",
  "license": "BSD-3-Clause"
}
```

Or equivalently:

``` json
{
  "package": "panacea-framework",
  "author": {
    "name": "Karli Kane",
    "email": "karli@inface.com",
    "for" :"InFace, Inc."
  },
  "license": "BSD-3-Clause"
}
```

And if Karli later gets permission to contribute some code to npm at work, she can add herself to AUTHORS:

```
Karli Kane <karli@inface.com> [InFace, Inc.]
```

The net result is that metadata in `package.json` will tell folks not just _what license terms_ they get, but also _who is giving the license_, since this might be different from the person who wrote the code. At least in terms of providing equivalent content, this makes `package.json` capable of saying everything you'd normally see in a well crafted `LICENSE` file with a copyright notice and MIT terms, a `LICENSE` copy of Apache 2.0 and a `NOTICE` file, GPL copy with header comments, &c.

Who is licensing can really matter. When patents are a concern, it matters tremendously whether the one writing the license might actually have any patents, and whether the license terms include a strong, weak, or no patent license. Some companies may also have blanket rules against using stuff from direct competitors with whom they do not get along.

It's come to my attention that spelunking in dusty crevices of the `package.json` spec is not a love I share with the community at large. In case all this people-string business is new: These strings and objects are used in [`author` and `contributors` in package.json](https://docs.npmjs.com/files/package.json#people-fields-author-contributors), as well as [`AUTHORS` files that automatically populate `contributors`](https://docs.npmjs.com/files/package.json#default-values).

Mentioning:

@seldo, who bore the initial brunt of hearing about this

@othiym23, because CLI, and we'd probably want a `package.json` doc update if we go this way

If you'd like to kick the tires of the new parsing and stringification packages, they are:

https://github.com/kemitchell/peoplestring-parse.js

https://github.com/kemitchell/peoplestring-stringify.js
