### PR TITLE
Use files stanza in package.json to exclude tests from publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
     "async": "^1.5.0",
     "tap": "^2.2.0",
     "underscore": "^1.8.3"
-  }
+  },
+  "files": [
+    "lib",
+    "AUTHORS"
+  ]
 }


### PR DESCRIPTION
Fixes #71.

This also came up recently in https://github.com/yargs/yargs/issues/468#issuecomment-206442013.

Would be nice to trim the package size a bit by excluding tests, and I prefer whitelisting files in `package.json` over blacklisting files in `.npmignore`, but I can be persuaded otherwise.

Here is the result of `npm pack` before and after this change:

```
# BEFORE
x package/package.json
x package/.npmignore
x package/README.md
x package/LICENSE
x package/.travis.yml
x package/AUTHORS
x package/lib/extract_description.js
x package/lib/fixer.js
x package/lib/make_warning.js
x package/lib/normalize.js
x package/lib/safe_format.js
x package/lib/typos.json
x package/lib/warning_messages.json
x package/test/basic.js
x package/test/dependencies.js
x package/test/strict.js
x package/test/github-urls.js
x package/test/consistency.js
x package/test/normalize.js
x package/test/scoped.js
x package/test/scripts.js
x package/test/typo.js
x package/test/mixedcase-names.js
x package/test/fixtures/no-description.json
x package/test/fixtures/async.json
x package/test/fixtures/bcrypt.json
x package/test/fixtures/coffee-script.json
x package/test/fixtures/http-server.json
x package/test/fixtures/movefile.json
x package/test/fixtures/badscripts.json
x package/test/fixtures/node-module_exist.json
x package/test/fixtures/npm.json
x package/test/fixtures/read-package-json.json
x package/test/fixtures/request.json
x package/test/fixtures/underscore.json

# AFTER
x package/package.json
x package/README.md
x package/LICENSE
x package/AUTHORS
x package/lib/extract_description.js
x package/lib/fixer.js
x package/lib/make_warning.js
x package/lib/normalize.js
x package/lib/safe_format.js
x package/lib/typos.json
x package/lib/warning_messages.json
```
