### PR TITLE
use parse-author module for author string parsing

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -2,6 +2,7 @@ var semver = require("semver")
 var validateLicense = require('validate-npm-package-license');
 var hostedGitInfo = require("hosted-git-info")
 var isBuiltinModule = require("is-builtin-module")
+var parseAuthor = require("parse-author")
 var depTypes = ["dependencies","devDependencies","optionalDependencies"]
 var extractDescription = require("./extract_description")
 var url = require("url")
@@ -357,15 +358,7 @@ function unParsePerson (person) {
 }
 
 function parsePerson (person) {
-  if (typeof person !== "string") return person
-  var name = person.match(/^([^\(<]+)/)
-  var url = person.match(/\(([^\)]+)\)/)
-  var email = person.match(/<([^>]+)>/)
-  var obj = {}
-  if (name && name[0].trim()) obj.name = name[0].trim()
-  if (email) obj.email = email[1];
-  if (url) obj.url = url[1];
-  return obj
+  return typeof person !== "string" ? person : parseAuthor(person)
 }
 
 function addOptionalDepsToDeps (data, warn) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "hosted-git-info": "^2.1.4",
     "is-builtin-module": "^1.0.0",
+    "parse-author": "^1.0.0",
     "semver": "2 || 3 || 4 || 5",
     "validate-npm-package-license": "^3.0.1"
   },


### PR DESCRIPTION
As of [1.0.0](https://github.com/jonschlinkert/parse-author/pull/3), [parse-author](https://www.npmjs.com/package/parse-author) is fully compatible with npm author strings. This PR outsources that parsing logic.

...I'll work on getting [stringify-author](https://www.npmjs.com/package/stringify-author) compatible next.
