### PR TITLE
Couple of README usage example fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ You may activate strict validation by passing true as the second argument.
 ```javascript
 normalizeData = require('normalize-package-data')
 packageData = require("./package.json")
-warnFn = function(msg) { console.error(msg) }
 normalizeData(packageData, true)
 // packageData is now normalized
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Basic usage is really simple. You call the function that normalize-package-data 
 
 ```javascript
 normalizeData = require('normalize-package-data')
-packageData = fs.readFileSync("package.json")
+packageData = require("./package.json")
 normalizeData(packageData)
 // packageData is now normalized
 ```
@@ -27,7 +27,7 @@ You may activate strict validation by passing true as the second argument.
 
 ```javascript
 normalizeData = require('normalize-package-data')
-packageData = fs.readFileSync("package.json")
+packageData = require("./package.json")
 warnFn = function(msg) { console.error(msg) }
 normalizeData(packageData, true)
 // packageData is now normalized
@@ -41,7 +41,7 @@ Optionally, you may pass a "warning" function. It gets called whenever the `norm
 
 ```javascript
 normalizeData = require('normalize-package-data')
-packageData = fs.readFileSync("package.json")
+packageData = require("./package.json")
 warnFn = function(msg) { console.error(msg) }
 normalizeData(packageData, warnFn)
 // packageData is now normalized. Any number of warnings may have been logged.


### PR DESCRIPTION
`normalize` mutates an `Object` argument, so we need to parse JSON in the README usage examples, rather than send it a buffer. We could also do `JSON.parse(fs.readFileSync())`, I suppose.

Second commit nails a `warnFn` declaration that isn't used in the example.

Selfless plug: [defence-cli](https://npmjs.com/packages/defence-cli) pulls fenced code blocks out of GitHub Markdown, like README.md, so you can do put test assertions in usage and `defence README.md | node` to sanity check.  With [replace-require-self](https://npmjs.com/packages/replace-require-self) you can do `require('normalized-package-data')` in README, `defence README.md | replace-require-self | node` in `package.json`, and it will rewrite the require to `require('./')` when it runs.

[Here's one of mine that does that](https://www.npmjs.com/package/reviewers-edition-parse).
