### PR TITLE
Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If the supplied data has an invalid name or version vield, `normalizeData` will 
 * If `bugs` field is an object, the resulting value only has email and url properties. If email and url properties are not strings, they are ignored. If no valid values for either email or url is found, bugs field will be removed.
 * If `homepage` field is not a string, it will be removed.
 * If the url in the `homepage` field does not specify a protocol, then http is assumed. For example, `myproject.org` will be changed to `http://myproject.org`.
-* If `homepage` field does not exist, but `repository` field points to a repository hosted on GitHub, the value of the `homepage` field gets set to an url in the form of https://github.com/[owner-name]/[repo-name]/ . If the repository field points to a GitHub Gist repo url, the associated http url is chosen.
+* If `homepage` field does not exist, but `repository` field points to a repository hosted on GitHub, the value of the `homepage` field gets set to an url in the form of https://github.com/[owner-name]/[repo-name]#readme . If the repository field points to a GitHub Gist repo url, the associated http url is chosen.
 
 ### Rules for name field
 


### PR DESCRIPTION
[hosted-git-info](https://github.com/npm/hosted-git-info) actually returns a link directly to the `readme` anchor.