### PR TITLE
Add extension when requiring `typos.json`

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -5,7 +5,7 @@ var isBuiltinModule = require("is-builtin-module")
 var depTypes = ["dependencies","devDependencies","optionalDependencies"]
 var extractDescription = require("./extract_description")
 var url = require("url")
-var typos = require("./typos")
+var typos = require("./typos.json")
 
 var fixer = module.exports = {
   // default warning function


### PR DESCRIPTION
This commit adds the `json` extension to the `require` call
for `typos.json` in `fixer.js`. This solves an issue with Webpack
preventing to bundle this package.