### PR TITLE
chore: bump version of semver package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -634,6 +634,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1816,7 +1817,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -3389,9 +3391,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "hosted-git-info": "^2.1.4",
     "resolve": "^1.10.0",
-    "semver": "2 || 3 || 4 || 5",
+    "semver": "^6.3.0",
     "validate-npm-package-license": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating the `semver` dependency.

Todos:
- [ ] bump minor version (& tag)
- [ ] publish package

Linked Issues:
- npm/node-semver#289