### PR TITLE
Avoid merging 'optionalDependencies' into 'dependencies'

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -131,10 +131,9 @@ var fixer = module.exports = {
 , fixDependencies: function(data, strict) {
     var loose = !strict
     objectifyDeps(data, this.warn)
-    addOptionalDepsToDeps(data, this.warn)
     this.fixBundleDependenciesField(data)
 
-    ;['dependencies','devDependencies'].forEach(function(deps) {
+    ;['dependencies','devDependencies','optionalDependencies'].forEach(function(deps) {
       if (!(deps in data)) return
       if (!data[deps] || typeof data[deps] !== "object") {
         this.warn("nonObjectDependencies", deps)
@@ -366,16 +365,6 @@ function parsePerson (person) {
   if (email) obj.email = email[1];
   if (url) obj.url = url[1];
   return obj
-}
-
-function addOptionalDepsToDeps (data, warn) {
-  var o = data.optionalDependencies
-  if (!o) return;
-  var d = data.dependencies || {}
-  Object.keys(o).forEach(function (k) {
-    d[k] = o[k]
-  })
-  data.dependencies = d
 }
 
 function depObjectify (deps, type, warn) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -26,7 +26,7 @@ function verifyFields (t, normalized, original) {
   // optional deps are folded in.
   t.deepEqual(normalized.optionalDependencies,
               original.optionalDependencies)
-  t.has(normalized.dependencies, original.optionalDependencies, "opt depedencies are copied into dependencies")
+  t.doesNotHave(normalized.dependencies, original.optionalDependencies, "opt depedencies are not copied into dependencies")
   t.has(normalized.dependencies, original.dependencies, "regular depedencies stay in place")
   t.deepEqual(normalized.devDependencies, original.devDependencies)
   t.type(normalized.bugs, "object", "bugs should become object")


### PR DESCRIPTION
Hi! I found a problem in the npm CLI, but it looks like the behavior is intentional. This fix works, but I'd love to hear if there's a better way to go about solving the problem. Thanks for your work on this project. 🌟 

cc: @myrne @feross

Fixes: https://github.com/npm/normalize-package-data/issues/91

---

Optional dependencies should not be merged into the list of dependencies
for the same reason that development dependencies shouldn't be merged
into the list of dependencies: they need to be treated differently.

Merging these objects in normalize-package-data bubbles up this bug
through read-package-json and into init-package-json, which creates a
problem where `npm init -y` will copy optional dependencies into the
`dependencies` object.

Instead of normalizing the dependency metadata, this module is mutating
it to have a different meaning, which seems to be a bug. This commit
resolves the mutation and treats the `optionalDependencies` key the same
way as the `devDependencies` key.

Fixes: https://github.com/npm/cli/issues/724