### PR TITLE
Treeshake `semver` dependendency

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -1,4 +1,5 @@
-var semver = require("semver")
+var isValidSemver = require("semver/functions/valid");
+var cleanSemver = require("semver/functions/clean");
 var validateLicense = require('validate-npm-package-license');
 var hostedGitInfo = require("hosted-git-info")
 var isBuiltinModule = require("resolve").isCore
@@ -187,10 +188,10 @@ var fixer = module.exports = {
       data.version = ""
       return true
     }
-    if (!semver.valid(data.version, loose)) {
+    if (!isValidSemver(data.version, loose)) {
       throw new Error('Invalid version: "'+ data.version + '"')
     }
-    data.version = semver.clean(data.version, loose)
+    data.version = cleanSemver(data.version, loose)
     return true
   }
 


### PR DESCRIPTION
`semver` exports each function as its own file, so it's useful to import them directly since `semver` is a relatively large dependency.

This is described and supported by their readme:

> You can also just load the module for the function that you care about, if you'd like to minimize your footprint.

