### PR TITLE
fix: account for "licence" as spelling variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If `version` field is given, the value of the version field must be a valid *sem
 
 ### Rules for license field
 
-The `license` field should be a valid *SPDX license expression* or one of the special values allowed by [validate-npm-package-license](https://npmjs.com/package/validate-npm-package-license). See [documentation for the license field in package.json](https://docs.npmjs.com/files/package.json#license).
+The `license`/`licence` field should be a valid *SPDX license expression* or one of the special values allowed by [validate-npm-package-license](https://npmjs.com/package/validate-npm-package-license). See [documentation for the license field in package.json](https://docs.npmjs.com/files/package.json#license).
 
 ## Credits
 
@@ -104,5 +104,5 @@ This package contains code based on read-package-json written by Isaac Z. Schlue
 
 ## License
 
-normalize-package-data is released under the [BSD 2-Clause License](http://opensource.org/licenses/MIT).  
-Copyright (c) 2013 Meryn Stol  
+normalize-package-data is released under the [BSD 2-Clause License](http://opensource.org/licenses/MIT).
+Copyright (c) 2013 Meryn Stol

--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -294,17 +294,18 @@ var fixer = module.exports = {
   }
 
 , fixLicenseField: function(data) {
-    if (!data.license) {
+    var license = data.license || data.licence;
+    if (!license) {
       return this.warn("missingLicense")
     } else{
       if (
-        typeof(data.license) !== 'string' ||
-        data.license.length < 1 ||
-        data.license.trim() === ''
+        typeof(license) !== 'string' ||
+        license.length < 1 ||
+        license.trim() === ''
       ) {
         this.warn("invalidLicense")
       } else {
-        if (!validateLicense(data.license).validForNewPackages)
+        if (!validateLicense(license).validForNewPackages)
           this.warn("invalidLicense")
       }
     }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Previously, this package did not account for the `package.json` field
being spelled as `licence` as it is spelled everywhere outside of the
US. The main `npm-cli` package, however, allows both, so this commit fixes
this issue so that a warning is not triggered in places where it is
spelled using the variant.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #107
