### PR TITLE
docs(README): fix license link to BSD-2-Clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,5 +104,5 @@ This package contains code based on read-package-json written by Isaac Z. Schlue
 
 ## License
 
-normalize-package-data is released under the [BSD 2-Clause License](http://opensource.org/licenses/MIT).  
+normalize-package-data is released under the [BSD 2-Clause License](https://opensource.org/licenses/BSD-2-Clause).  
 Copyright (c) 2013 Meryn Stol  


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Link of License section in README was pointing to MIT License, replaced by proper BSD-2-Clause.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Fixes #118