### PR TITLE
upgrades hosted-git-info to v4.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -382,9 +382,27 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -634,6 +652,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1816,7 +1835,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "hosted-git-info": "^2.1.4",
+    "hosted-git-info": "^4.0.2",
     "resolve": "^1.10.0",
     "semver": "2 || 3 || 4 || 5",
     "validate-npm-package-license": "^3.0.1"


### PR DESCRIPTION
Upgrades `hosted-git-info` to ^4.0.2 to fix a security vulnerability.

Advisory: https://www.npmjs.com/advisories/1677

I have branched from tag `v2.5.0` so a new branch should be made for `v2.5.0` that can be used as the base for this PR. The intention is for this change to create `v2.5.1`

All test passing:

![Screenshot 2021-05-07 at 12 22 35](https://user-images.githubusercontent.com/78593007/117443232-c6e2ad00-af2f-11eb-9c18-ff42724cfb91.png)


