### PR TITLE
fix: account for "licence" as spelling variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If `version` field is given, the value of the version field must be a valid *sem
 
 ### Rules for license field
 
-The `license` field should be a valid *SPDX license expression* or one of the special values allowed by [validate-npm-package-license](https://npmjs.com/package/validate-npm-package-license). See [documentation for the license field in package.json](https://docs.npmjs.com/files/package.json#license).
+The `license`/`licence` field should be a valid *SPDX license expression* or one of the special values allowed by [validate-npm-package-license](https://npmjs.com/package/validate-npm-package-license). See [documentation for the license field in package.json](https://docs.npmjs.com/files/package.json#license).
 
 ## Credits
 
@@ -104,5 +104,5 @@ This package contains code based on read-package-json written by Isaac Z. Schlue
 
 ## License
 
-normalize-package-data is released under the [BSD 2-Clause License](https://opensource.org/licenses/BSD-2-Clause).  
-Copyright (c) 2013 Meryn Stol  
+normalize-package-data is released under the [BSD 2-Clause License](https://opensource.org/licenses/BSD-2-Clause).
+Copyright (c) 2013 Meryn Stol

--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -323,20 +323,19 @@ module.exports = {
   },
 
   fixLicenseField: function (data) {
-    if (!data.license) {
+    const license = data.license || data.licence
+    if (!license) {
       return this.warn('missingLicense')
-    } else {
-      if (
-        typeof (data.license) !== 'string' ||
-        data.license.length < 1 ||
-        data.license.trim() === ''
-      ) {
-        this.warn('invalidLicense')
-      } else {
-        if (!validateLicense(data.license).validForNewPackages) {
-          this.warn('invalidLicense')
-        }
-      }
+    }
+    if (
+      typeof (license) !== 'string' ||
+      license.length < 1 ||
+      license.trim() === ''
+    ) {
+      return this.warn('invalidLicense')
+    }
+    if (!validateLicense(license).validForNewPackages) {
+      return this.warn('invalidLicense')
     }
   },
 }

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -178,6 +178,22 @@ tap.test("don't fail when license is just a space", function (t) {
   t.end()
 })
 
+tap.test("don't fail when license is licence", function (t) {
+  var warnings = []
+  function warn (w) {
+    warnings.push(w)
+  }
+  normalize({
+    description: 'description',
+    readme: 'readme',
+    repository: 'https://npmjs.org',
+    licence: 'MIT',
+  }, warn)
+
+  t.same(warnings, [])
+  t.end()
+})
+
 tap.test('gist bugs url', function (t) {
   var d = {
     repository: 'git@gist.github.com:1234567.git',


### PR DESCRIPTION
Previously, this package did not account for the package.json field
being spelled as "licence" as it is spelled everywhere outside of the
US. The main npm-cli package, however, allows both, so this commit fixes
this issue so that a warning is not triggered in places where it is
spelled using the variant.

Fixes #107
Rebase of #115 