### PR TITLE
fix: do not overwrite bundled dependency ranges with *

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -129,7 +129,7 @@ module.exports = {
           if (!data.dependencies) {
             data.dependencies = {}
           }
-          if (Object.prototype.hasOwnProperty.call(data.dependencies, bd)) {
+          if (!Object.prototype.hasOwnProperty.call(data.dependencies, bd)) {
             this.warn('nonDependencyBundleDependency', bd)
             data.dependencies[bd] = '*'
           }

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -32,12 +32,21 @@ tap.test('warn if bundleDependencies array contains anything else but strings', 
   normalize({
     bundleDependencies: ['abc', 123, { foo: 'bar' }],
   }, warn)
+  var pkg = {
+    dependencies: {
+      def: '^1.0.0',
+    },
+    bundleDependencies: ['abc', 'def', 123, { foo: 'bar' }],
+  }
+  normalize(pkg, warn)
 
   var wanted1 = safeFormat(warningMessages.nonStringBundleDependency, 123)
   var wanted2 = safeFormat(warningMessages.nonStringBundleDependency, { foo: 'bar' })
   var wanted3 = safeFormat(warningMessages.nonDependencyBundleDependency, 'abc')
   t.ok(~warnings.indexOf(wanted1), wanted1)
   t.ok(~warnings.indexOf(wanted2), wanted2)
-  t.notOk(~warnings.indexOf(wanted3), wanted3)
+  t.ok(~warnings.indexOf(wanted3), wanted3)
+  t.equal(pkg.dependencies.abc, '*', 'added bundled dep to dependencies with *')
+  t.equal(pkg.dependencies.def, '^1.0.0', 'left def dependency alone')
   t.end()
 })


### PR DESCRIPTION
this corrects a regression where we started overwriting dependencies that are present in both `dependencies` and `bundleDependencies` with a `*` when the original intent was to _add_ dependencies that were present in `bundleDependencies` but _not_ in `dependencies` with a range of `*`

this fixes the issue where our own published package.json has `*` for the range for every dependency