### PR TITLE
Fix: Upgrade semver version to 7.5.2 to fix ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "hosted-git-info": "^6.0.0",
     "is-core-module": "^2.8.1",
-    "semver": "^7.3.5",
+    "semver": "^7.5.2",
     "validate-npm-package-license": "^3.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
At the moment, normalize-package-data uses version 7.3.5 of semver. The problem arises when launching the command 'yarn audit' due to a vulnerability in regular expression denial of service via the function 'new Range'. You can find more information about this vulnerability in the following reference: https://github.com/advisories/GHSA-c2qf-rxjj-qqgw

This pull request (PR) proposes upgrading the semver dependency to version 7.5.2 because it includes the necessary patches for versions greater than or equal to 7.5.2.