### PR TITLE
fix: use `isBuiltin` instead of `builtinModules`

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -2,7 +2,7 @@ var isValidSemver = require('semver/functions/valid')
 var cleanSemver = require('semver/functions/clean')
 var validateLicense = require('validate-npm-package-license')
 var hostedGitInfo = require('hosted-git-info')
-var moduleBuiltin = require('node:module')
+var { isBuiltin } = require('node:module')
 var depTypes = ['dependencies', 'devDependencies', 'optionalDependencies']
 var extractDescription = require('./extract_description')
 var url = require('url')
@@ -231,7 +231,7 @@ module.exports = {
       data.name = data.name.trim()
     }
     ensureValidName(data.name, strict, options.allowLegacyCase)
-    if (moduleBuiltin.builtinModules.includes(data.name)) {
+    if (isBuiltin(data.name)) {
       this.warn('conflictingName', data.name)
     }
   },


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Remember #224? Since this package no longer supports anything below node 18.6.0, we can switch to `isBuiltin` instead, as originally suggested in my previous PR.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
https://nodejs.org/api/module.html#moduleisbuiltinmodulename
