### PR TITLE
fix: use `URL.canParse` instead of runtime deprecated `url.parse` api

### DIFF
--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -5,7 +5,6 @@ var hostedGitInfo = require('hosted-git-info')
 var { isBuiltin } = require('node:module')
 var depTypes = ['dependencies', 'devDependencies', 'optionalDependencies']
 var extractDescription = require('./extract_description')
-var url = require('url')
 var typos = require('./typos.json')
 
 var isEmail = str => str.includes('@') && (str.indexOf('@') < str.lastIndexOf('.'))
@@ -269,8 +268,7 @@ module.exports = {
       if (typeof data.bugs === 'string') {
         if (isEmail(data.bugs)) {
           data.bugs = { email: data.bugs }
-        /* eslint-disable-next-line node/no-deprecated-api */
-        } else if (url.parse(data.bugs).protocol) {
+        } else if (URL.canParse(data.bugs)) {
           data.bugs = { url: data.bugs }
         } else {
           this.warn('nonEmailUrlBugsString')
@@ -280,8 +278,7 @@ module.exports = {
         var oldBugs = data.bugs
         data.bugs = {}
         if (oldBugs.url) {
-          /* eslint-disable-next-line node/no-deprecated-api */
-          if (typeof (oldBugs.url) === 'string' && url.parse(oldBugs.url).protocol) {
+          if (URL.canParse(oldBugs.url)) {
             data.bugs.url = oldBugs.url
           } else {
             this.warn('nonUrlBugsUrlField')
@@ -317,8 +314,7 @@ module.exports = {
       this.warn('nonUrlHomepage')
       return delete data.homepage
     }
-    /* eslint-disable-next-line node/no-deprecated-api */
-    if (!url.parse(data.homepage).protocol) {
+    if (!URL.canParse(data.homepage)) {
       data.homepage = 'http://' + data.homepage
     }
   },

--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -1,3 +1,4 @@
+var { URL } = require('node:url')
 var isValidSemver = require('semver/functions/valid')
 var cleanSemver = require('semver/functions/clean')
 var validateLicense = require('validate-npm-package-license')


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Backport of npm/package-json#150

`url.parse` is runtime deprecated. It looks like it's being used here to somewhat check if the string is a valid URL, so I've changed that to `URL.canParse` which is the compliant way of checking whether a string is a valid and parsable URL. `URL.canParse` was added in node `18.17.0` and `19.9.0`

Closes #242

## References
pnpm/pnpm#9529
https://developer.mozilla.org/en-US/docs/Web/API/URL/canParse_static
https://nodejs.org/api/url.html#urlcanparseinput-base
