### PR TITLE
deps & engine update

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -91,20 +91,17 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 18.17.0
-          - 18.x
-          - 20.5.0
+          - 20.17.0
           - 20.x
+          - 22.9.0
           - 22.x
         exclude:
           - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 20.5.0
+            node-version: 20.17.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 20.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.9.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,20 +67,17 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 18.17.0
-          - 18.x
-          - 20.5.0
+          - 20.17.0
           - 20.x
+          - 22.9.0
           - 22.x
         exclude:
           - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 20.5.0
+            node-version: 20.17.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 20.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.9.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lib/"
   ],
   "engines": {
-    "node": "^18.17.0 || >=20.5.0"
+    "node": "^20.17.0 || >=22.9.0"
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",


### PR DESCRIPTION
- **deps: hosted-git-info@9.0.0**
- **fix!: align to npm 11 node engine range BREAKING CHANGE: `normalize-package-data` now supports node `^20.17.0 || >=22.9.0`**
